### PR TITLE
implement flag syntax and "optional" flag

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -10,12 +10,23 @@ import (
 
 type (
 	path struct {
+		flags    []string
 		selector string
 		acc      string
 		parsers  []parser
 		loader   *loader
 	}
 )
+
+func (p *path) hasFlag(flag string) bool {
+	for _, v := range p.flags {
+		if v == flag {
+			return true
+		}
+	}
+
+	return false
+}
 
 const (
 	accessorAttr = "attr"
@@ -72,7 +83,22 @@ func parseFunctionSignature(s string) (string, string) {
 
 func parseTag(tag reflect.StructTag) (*path, error) {
 	p := &path{}
-	for i, part := range strings.Split(tag.Get("sq"), " | ") {
+
+	s := tag.Get("sq")
+
+	if len(s) > 0 && s[0] == '(' {
+		if end := strings.Index(s, ")"); end != -1 {
+			for _, e := range strings.Split(s[1:end], ",") {
+				if e = strings.TrimSpace(e); e != "" {
+					p.flags = append(p.flags, e)
+				}
+			}
+
+			s = strings.TrimLeft(s[end:], ") ")
+		}
+	}
+
+	for i, part := range strings.Split(s, " | ") {
 		part = strings.TrimSpace(part)
 		switch i {
 		case 0:

--- a/extract_test.go
+++ b/extract_test.go
@@ -120,6 +120,14 @@ func TestParseTag(t *testing.T) {
 			},
 			nil,
 		},
+		{`sq:"() p"`, &path{flags: []string{}, selector: "p"}, nil},
+		{`sq:"( ) p"`, &path{flags: []string{}, selector: "p"}, nil},
+		{`sq:"(opt1) p"`, &path{flags: []string{"opt1"}, selector: "p"}, nil},
+		{`sq:"( opt1 ) p"`, &path{flags: []string{"opt1"}, selector: "p"}, nil},
+		{`sq:"(opt1,opt2) p"`, &path{flags: []string{"opt1", "opt2"}, selector: "p"}, nil},
+		{`sq:"( opt1 , opt2 ) p"`, &path{flags: []string{"opt1", "opt2"}, selector: "p"}, nil},
+		{`sq:"(opt1,opt2,opt3) p"`, &path{flags: []string{"opt1", "opt2", "opt3"}, selector: "p"}, nil},
+		{`sq:"(    opt1 ,opt2, opt3    )    p"`, &path{flags: []string{"opt1", "opt2", "opt3"}, selector: "p"}, nil},
 
 		// bad
 		{`sq:"p.last | fuzzy"`, nil, fmt.Errorf("Bad accessor: %q", `fuzzy`)},
@@ -135,6 +143,15 @@ func TestParseTag(t *testing.T) {
 				t.Errorf("Expected error %q, got %q", test.err, err)
 			}
 			continue
+		}
+		if len(p.flags) != len(test.p.flags) {
+			t.Errorf("Expected %#v, got %#v", test.p.flags, p.flags)
+		} else {
+			for i := 0; i < len(p.flags); i++ {
+				if p.flags[i] != test.p.flags[i] {
+					t.Errorf("Expected %#v, got %#v", test.p.flags, p.flags)
+				}
+			}
 		}
 		if p.selector != test.p.selector {
 			t.Errorf("Expected %q, got %q", test.p.selector, p.selector)

--- a/sq.go
+++ b/sq.go
@@ -62,6 +62,10 @@ func hydrateValue(v *reflect.Value, sel *goquery.Selection, p *path) []error {
 	if p != nil && len(p.selector) > 0 && p.selector != "." && !sel.Is(p.selector) {
 		sel = sel.Find(p.selector)
 		if sel.Size() == 0 {
+			if p.hasFlag("optional") {
+				return nil
+			}
+
 			return []error{fmt.Errorf("%q did not match", p.selector)}
 		}
 	}

--- a/test/types.go
+++ b/test/types.go
@@ -57,6 +57,7 @@ type (
 		Stylesheet     *css.Stylesheet      `sq:"style:first-of-type"`
 		Stylesheets    []*css.Stylesheet    `sq:"style"`
 		CustomType     CustomType           `sq:"p.string"`
+		Optional       string               `sq:"(optional) blink"`
 
 		// errs
 		Map                 map[string]interface{} `sq:"div"`


### PR DESCRIPTION
the first commit here implements a flag syntax by prefixing the struct tag
with (flag1,flag2)

the second commit uses this syntax to implement an "optional" flag, so if a
selector is known to only sometimes be included, it won't cause the parsing to
fail